### PR TITLE
Improve tool validation and logging

### DIFF
--- a/terminal-mcp-agent/src/agent/graph.py
+++ b/terminal-mcp-agent/src/agent/graph.py
@@ -1,19 +1,22 @@
-import os
-from dotenv import load_dotenv
-from typing import Union
+"""LangGraph workflow for the Terminal MCP agent."""
 
-from langgraph.graph import StateGraph, START, END
+import logging
+import os
+
+from dotenv import load_dotenv
 from langchain_core.runnables import RunnableConfig
 from langchain_google_genai import ChatGoogleGenerativeAI
+from langgraph.graph import END, START, StateGraph
+from pydantic import ValidationError
 
-from .state import AgentState
-from .configuration import Configuration # Will be used for model config
+from .configuration import Configuration  # Will be used for model config
 from .prompts import COMMAND_PARSER_INSTRUCTIONS, get_current_date
+from .state import AgentState
 from .tools_and_schemas import (
-    ListFilesTool,
-    ReadFileTool,
     CreateDirectoryTool,
-    ParsedCommand # Using this generic schema for now for the output of parser
+    ListFilesTool,
+    ParsedCommand,  # Using this generic schema for now for the output of parser
+    ReadFileTool,
 )
 
 # Load environment variables from .env file
@@ -23,15 +26,14 @@ GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 if not GEMINI_API_KEY:
     raise ValueError("GEMINI_API_KEY is not set in the environment or .env file")
 
+logger = logging.getLogger(__name__)
+
 # --- Node Definitions ---
 
 def parse_user_command(state: AgentState, config: RunnableConfig) -> dict:
-    """
-    Parses the user's natural language command into a structured MCP tool call
-    using Gemini with structured output.
-    """
-    print(f"--- Debug: Entering parse_user_command ---")
-    print(f"--- Debug: User command: {state['user_command']} ---")
+    """Parse the user's command using Gemini and return a structured tool call."""
+    logger.debug("Entering parse_user_command")
+    logger.debug("User command: %s", state['user_command'])
 
     app_config = Configuration.from_runnable_config(config)
     llm = ChatGoogleGenerativeAI(
@@ -51,32 +53,53 @@ def parse_user_command(state: AgentState, config: RunnableConfig) -> dict:
 
     try:
         parsed_result = structured_llm.invoke(prompt)
-        print(f"--- Debug: LLM raw parsed_result: {parsed_result} ---")
-        if isinstance(parsed_result, ParsedCommand) and parsed_result.tool_name != "NoSuitableToolFound":
-            # TODO: Validate that parsed_result.tool_name is one of our actual tool classes
-            # and that parsed_result.args match the schema of that tool.
-            # For now, we assume the LLM gets it right based on the prompt.
-            return {
-                "parsed_command": {"tool_name": parsed_result.tool_name, "args": parsed_result.args},
-                "error_message": None
-            }
-        else:
-            error_msg = f"No suitable tool found or LLM failed to identify one for command: {state['user_command']}"
-            if isinstance(parsed_result, ParsedCommand) and parsed_result.args:
-                 error_msg = f"No suitable tool found for command: {parsed_result.args.get('original_command', state['user_command'])}"
-            print(f"--- Debug: {error_msg} ---")
+        logger.debug("LLM raw parsed_result: %s", parsed_result)
+        if not isinstance(parsed_result, ParsedCommand):
+            raise ValueError("LLM did not return ParsedCommand")
+        if parsed_result.tool_name == "NoSuitableToolFound":
+            error_msg = (
+                f"No suitable tool found for command: "
+                f"{parsed_result.args.get('original_command', state['user_command'])}"
+            )
+            logger.debug(error_msg)
             return {"parsed_command": None, "error_message": error_msg}
+
+        tool_map = {
+            ListFilesTool.__name__: ListFilesTool,
+            ReadFileTool.__name__: ReadFileTool,
+            CreateDirectoryTool.__name__: CreateDirectoryTool,
+        }
+        tool_class = tool_map.get(parsed_result.tool_name)
+        if tool_class is None:
+            error_msg = f"Unknown tool: {parsed_result.tool_name}"
+            logger.error(error_msg)
+            return {"parsed_command": None, "error_message": error_msg}
+
+        try:
+            validated = tool_class(**parsed_result.args)
+        except ValidationError as e:
+            error_msg = f"Invalid arguments for {parsed_result.tool_name}: {e}"
+            logger.error(error_msg)
+            return {"parsed_command": None, "error_message": error_msg}
+
+        return {
+            "parsed_command": {
+                "tool_name": parsed_result.tool_name,
+                "args": validated.model_dump() if hasattr(validated, "model_dump") else validated.dict(),
+            },
+            "error_message": None,
+        }
     except Exception as e:
-        print(f"--- Debug: Exception during LLM invocation or parsing: {e} ---")
+        logger.exception("Exception during LLM invocation or parsing: %s", e)
         return {"parsed_command": None, "error_message": f"Error parsing command: {str(e)}"}
 
 def execute_mcp_tool(state: AgentState, config: RunnableConfig) -> dict:
-    """
-    Executes the parsed MCP tool.
+    """Execute the parsed MCP tool.
+
     Placeholder: For now, it just logs the command and returns a mock success.
     Actual tool execution will be implemented later with MCP server classes.
     """
-    print(f"--- Debug: Entering execute_mcp_tool ---")
+    logger.debug("Entering execute_mcp_tool")
     parsed_command = state.get('parsed_command')
     if not parsed_command:
         return {"tool_output": None, "error_message": "No command was parsed for execution."}
@@ -84,7 +107,7 @@ def execute_mcp_tool(state: AgentState, config: RunnableConfig) -> dict:
     tool_name = parsed_command.get('tool_name')
     args = parsed_command.get('args', {})
 
-    print(f"--- Debug: Attempting to execute tool: {tool_name} with args: {args} ---")
+    logger.debug("Attempting to execute tool: %s with args: %s", tool_name, args)
 
     # Mock execution for now
     # In the future, this will dispatch to actual tool implementations (e.g., FilesystemMCPServer.list_files(args))
@@ -95,22 +118,22 @@ def execute_mcp_tool(state: AgentState, config: RunnableConfig) -> dict:
     elif tool_name == CreateDirectoryTool.__name__:
         output = f"Mock success: '{tool_name}' called to create directory '{args.get('path')}'"
     else:
-        print(f"--- Debug: Unknown tool_name: {tool_name} ---")
+        logger.error("Unknown tool_name: %s", tool_name)
         return {"tool_output": None, "error_message": f"Unknown tool: {tool_name}"}
 
-    print(f"--- Debug: Mock tool output: {output} ---")
+    logger.debug("Mock tool output: %s", output)
     return {"tool_output": output, "error_message": None}
 
 def format_tool_output(state: AgentState, config: RunnableConfig) -> dict:
-    """
-    Formats the tool's output for display.
+    """Format the tool's output for display.
+
     Placeholder: For now, it's a simple pass-through or basic formatting.
     """
-    print(f"--- Debug: Entering format_tool_output ---")
+    logger.debug("Entering format_tool_output")
     if state.get('error_message'):
         # If there's an error message, that should be the primary output to the user
         final_output = f"Error: {state['error_message']}"
-        print(f"--- Debug: Formatting error message: {final_output} ---")
+        logger.debug("Formatting error message: %s", final_output)
         # Clear error after displaying, or decide on error handling flow
         return {"tool_output": final_output, "error_message": None, "parsed_command": None, "user_command": None}
 
@@ -127,7 +150,7 @@ def format_tool_output(state: AgentState, config: RunnableConfig) -> dict:
         except TypeError:
             final_output = str(tool_output)
 
-    print(f"--- Debug: Formatted output: {final_output} ---")
+    logger.debug("Formatted output: %s", final_output)
     # Reset state for next command
     return {"tool_output": final_output, "parsed_command": None, "user_command": None}
 
@@ -135,15 +158,15 @@ def format_tool_output(state: AgentState, config: RunnableConfig) -> dict:
 # --- Conditional Edge Logic ---
 
 def should_execute_tool(state: AgentState) -> str:
-    """Determines if a command was successfully parsed and is ready for execution."""
-    print(f"--- Debug: Entering should_execute_tool ---")
+    """Return the next node based on parsing results."""
+    logger.debug("Entering should_execute_tool")
     if state.get('error_message'):
-        print(f"--- Debug: Error detected, routing to format_tool_output ---")
+        logger.debug("Error detected, routing to format_tool_output")
         return "format_tool_output" # Route to format output to show the error
     if state.get('parsed_command') and state['parsed_command'].get('tool_name') != "NoSuitableToolFound":
-        print(f"--- Debug: Command parsed, routing to execute_mcp_tool ---")
+        logger.debug("Command parsed, routing to execute_mcp_tool")
         return "execute_mcp_tool"
-    print(f"--- Debug: No suitable tool or error in parsing, routing to format_tool_output ---")
+    logger.debug("No suitable tool or error in parsing, routing to format_tool_output")
     # If no tool found or other parsing issue not caught as an error yet
     return "format_tool_output"
 
@@ -174,33 +197,34 @@ agent_graph = builder.compile()
 
 # --- Test Invocation (Optional, for quick testing if run directly) ---
 if __name__ == "__main__":
-    print("Testing agent graph directly (mock execution)...")
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Testing agent graph directly (mock execution)...")
 
     # Load configuration for the test
     test_config = RunnableConfig(configurable={"query_generator_model": "gemini-pro"}) # Example model
 
     # Example 1: List files
     inputs1 = AgentState(user_command="list files in my_documents")
-    print(f"\nInvoking graph with: {inputs1}")
+    logger.info("\nInvoking graph with: %s", inputs1)
     for event in agent_graph.stream(inputs1, config=test_config):
-        print(f"Event: {event}")
+        logger.info("Event: %s", event)
 
     # Example 2: Read a file
     inputs2 = AgentState(user_command="cat /etc/passwd")
-    print(f"\nInvoking graph with: {inputs2}")
+    logger.info("\nInvoking graph with: %s", inputs2)
     for event in agent_graph.stream(inputs2, config=test_config):
-        print(f"Event: {event}")
+        logger.info("Event: %s", event)
 
     # Example 3: Unknown command
     inputs3 = AgentState(user_command="what's the weather like?")
-    print(f"\nInvoking graph with: {inputs3}")
+    logger.info("\nInvoking graph with: %s", inputs3)
     for event in agent_graph.stream(inputs3, config=test_config):
-        print(f"Event: {event}")
+        logger.info("Event: %s", event)
 
     # Example 4: Command that might cause parsing error (if LLM struggles)
     # inputs4 = AgentState(user_command="!@#$%^&*()")
-    # print(f"\nInvoking graph with: {inputs4}")
+    # logger.info("\nInvoking graph with: %s", inputs4)
     # for event in agent_graph.stream(inputs4, config=test_config):
-    #     print(f"Event: {event}")
+    #     logger.info("Event: %s", event)
 
-    print("\nGraph testing complete.")
+    logger.info("\nGraph testing complete.")


### PR DESCRIPTION
## Summary
- replace all `print` calls in `graph.py` with structured logging
- validate parsed commands against known tools and schemas
- add minimal module and function docstrings

## Testing
- `ruff check src/agent/graph.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b05c750883318b547997d46af023